### PR TITLE
feat: Add init methods to engine class for the Vector Store

### DIFF
--- a/src/llama_index_alloydb_pg/engine.py
+++ b/src/llama_index_alloydb_pg/engine.py
@@ -560,8 +560,8 @@ class AlloyDBEngine:
         for column in metadata_columns:
             nullable = "NOT NULL" if not column.nullable else ""
             create_table_query += f',\n"{column.name}" {column.data_type} {nullable}'
-        if stores_text:
-            create_table_query += f""",\n"{text_column}" TEXT"""
+        nullable_text = "NOT NULL" if stores_text else ""
+        create_table_query += f""",\n"{text_column}" TEXT {nullable_text}"""
         create_table_query += "\n);"
         create_index_query = f"""CREATE INDEX "{table_name}_idx_ref_doc_id" ON "{schema_name}"."{table_name}" ("{ref_doc_id_column}");"""
 

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -281,7 +281,7 @@ class TestEngineAsync:
                 "data_type": "character varying",
                 "is_nullable": "YES",
             },
-            {"column_name": "text", "data_type": "text", "is_nullable": "YES"},
+            {"column_name": "text", "data_type": "text", "is_nullable": "NO"},
         ]
         for row in results:
             assert row in expected
@@ -439,7 +439,7 @@ class TestEngineSync:
                 "data_type": "character varying",
                 "is_nullable": "YES",
             },
-            {"column_name": "text", "data_type": "text", "is_nullable": "YES"},
+            {"column_name": "text", "data_type": "text", "is_nullable": "NO"},
         ]
         for row in results:
             assert row in expected


### PR DESCRIPTION
Changes: Adds Vector Store

Tests: Passing in local running against hosted Alloy DB 

Reviewer points: 
1. Table schema
2. Nullable fields
3. Should we restructure Test classes to inherit from a common parent like `TestEngineBase` and hold fixtures in one place? Not sure whether it creates readability issues. [Sample](https://paste.googleplex.com/5968880769171456)