### PR TITLE
fix: VectorStore node column default is now node_data

### DIFF
--- a/src/llama_index_alloydb_pg/async_vectorstore.py
+++ b/src/llama_index_alloydb_pg/async_vectorstore.py
@@ -58,7 +58,7 @@ class AsyncAlloyDBVectorStore(BasePydanticVectorStore):
         metadata_json_column: str = "li_metadata",
         metadata_columns: List[str] = [],
         ref_doc_id_column: str = "ref_doc_id",
-        node_column: str = "node",
+        node_column: str = "node_data",
         stores_text: bool = True,
         is_embedding_query: bool = True,
     ):
@@ -74,7 +74,7 @@ class AsyncAlloyDBVectorStore(BasePydanticVectorStore):
             metadata_json_column (str): Column to store metadata as JSON. Defaults to "li_metadata".
             metadata_columns (List[str]): Column(s) that represent extracted metadata keys in their own columns.
             ref_doc_id_column (str): Column that represents id of a node's parent document. Defaults to "ref_doc_id".
-            node_column (str): Column that represents the whole JSON node. Defaults to "node".
+            node_column (str): Column that represents the whole JSON node. Defaults to "node_data".
             stores_text (bool): Whether the table stores text. Defaults to "True".
             is_embedding_query (bool): Whether the table query can have embeddings. Defaults to "True".
 
@@ -110,7 +110,7 @@ class AsyncAlloyDBVectorStore(BasePydanticVectorStore):
         metadata_json_column: str = "li_metadata",
         metadata_columns: List[str] = [],
         ref_doc_id_column: str = "ref_doc_id",
-        node_column: str = "node",
+        node_column: str = "node_data",
         stores_text: bool = True,
         is_embedding_query: bool = True,
     ) -> AsyncAlloyDBVectorStore:
@@ -126,7 +126,7 @@ class AsyncAlloyDBVectorStore(BasePydanticVectorStore):
             metadata_json_column (str): Column to store metadata as JSON. Defaults to "li_metadata".
             metadata_columns (List[str]): Column(s) that represent extracted metadata keys in their own columns.
             ref_doc_id_column (str): Column that represents id of a node's parent document. Defaults to "ref_doc_id".
-            node_column (str): Column that represents the whole JSON node. Defaults to "node".
+            node_column (str): Column that represents the whole JSON node. Defaults to "node_data".
             stores_text (bool): Whether the table stores text. Defaults to "True".
             is_embedding_query (bool): Whether the table query can have embeddings. Defaults to "True".
 
@@ -228,7 +228,7 @@ class AsyncAlloyDBVectorStore(BasePydanticVectorStore):
             {self._ref_doc_id_column},
             {self._node_column}
             {metadata_col_names}
-        ) VALUES (:node_id, :text, :embedding, :li_metadata, :ref_doc_id, :node {metadata_col_values})
+        ) VALUES (:node_id, :text, :embedding, :li_metadata, :ref_doc_id, :node_data {metadata_col_values})
         """
         node_values_list = []
         for node in nodes:
@@ -238,7 +238,7 @@ class AsyncAlloyDBVectorStore(BasePydanticVectorStore):
                 "embedding": str(node.get_embedding()),
                 "li_metadata": json.dumps(node.to_dict()["metadata"]),
                 "ref_doc_id": node.ref_doc_id,
-                "node": node.to_json(),
+                "node_data": node.to_json(),
             }
             for metadata_column in self._metadata_columns:
                 node_values[metadata_column] = node.metadata.get(metadata_column)

--- a/src/llama_index_alloydb_pg/engine.py
+++ b/src/llama_index_alloydb_pg/engine.py
@@ -514,7 +514,7 @@ class AlloyDBEngine:
         metadata_json_column: str = "li_metadata",
         metadata_columns: List[Column] = [],
         ref_doc_id_column: str = "ref_doc_id",
-        node_column: str = "node",
+        node_column: str = "node_data",
         stores_text: bool = True,
         overwrite_existing: bool = False,
     ) -> None:
@@ -530,7 +530,7 @@ class AlloyDBEngine:
             metadata_json_column (str): Column to store metadata as JSON. Defaults to "li_metadata".
             metadata_columns (List[str]): Column(s) that represent extracted metadata keys in their own columns.
             ref_doc_id_column (str): Column that represents id of a node's parent document. Defaults to "ref_doc_id".
-            node_column (str): Column that represents the whole JSON node. Defaults to "node".
+            node_column (str): Column that represents the whole JSON node. Defaults to "node_data".
             stores_text (bool): Whether the table stores text. Defaults to "True".
             overwrite_existing (bool): Whether to drop existing table. Default: False.
 
@@ -587,7 +587,7 @@ class AlloyDBEngine:
         metadata_json_column: str = "li_metadata",
         metadata_columns: List[Column] = [],
         ref_doc_id_column: str = "ref_doc_id",
-        node_column: str = "node",
+        node_column: str = "node_data",
         stores_text: bool = True,
         overwrite_existing: bool = False,
     ) -> None:
@@ -603,7 +603,7 @@ class AlloyDBEngine:
             metadata_json_column (str): Column to store metadata as JSON. Defaults to "li_metadata".
             metadata_columns (List[str]): Column(s) that represent extracted metadata keys in their own columns.
             ref_doc_id_column (str): Column that represents id of a node's parent document. Defaults to "ref_doc_id".
-            node_column (str): Column that represents the whole JSON node. Defaults to "node".
+            node_column (str): Column that represents the whole JSON node. Defaults to "node_data".
             stores_text (bool): Whether the table stores text. Defaults to "True".
             overwrite_existing (bool): Whether to drop existing table. Default: False.
 
@@ -638,7 +638,7 @@ class AlloyDBEngine:
         metadata_json_column: str = "li_metadata",
         metadata_columns: List[Column] = [],
         ref_doc_id_column: str = "ref_doc_id",
-        node_column: str = "node",
+        node_column: str = "node_data",
         stores_text: bool = True,
         overwrite_existing: bool = False,
     ) -> None:
@@ -654,7 +654,7 @@ class AlloyDBEngine:
             metadata_json_column (str): Column to store metadata as JSON. Defaults to "li_metadata".
             metadata_columns (List[str]): Column(s) that represent extracted metadata keys in their own columns.
             ref_doc_id_column (str): Column that represents id of a node's parent document. Defaults to "ref_doc_id".
-            node_column (str): Column that represents the whole JSON node. Defaults to "node".
+            node_column (str): Column that represents the whole JSON node. Defaults to "node_data".
             stores_text (bool): Whether the table stores text. Defaults to "True".
             overwrite_existing (bool): Whether to drop existing table. Default: False.
 

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -278,7 +278,7 @@ class TestEngineAsync:
                 "data_type": "USER-DEFINED",
                 "is_nullable": "YES",
             },
-            {"column_name": "node", "data_type": "json", "is_nullable": "NO"},
+            {"column_name": "node_data", "data_type": "json", "is_nullable": "NO"},
             {
                 "column_name": "ref_doc_id",
                 "data_type": "character varying",
@@ -453,7 +453,7 @@ class TestEngineSync:
                 "data_type": "USER-DEFINED",
                 "is_nullable": "YES",
             },
-            {"column_name": "node", "data_type": "json", "is_nullable": "NO"},
+            {"column_name": "node_data", "data_type": "json", "is_nullable": "NO"},
             {
                 "column_name": "ref_doc_id",
                 "data_type": "character varying",


### PR DESCRIPTION
Addresses an open comment on another PR: [link](https://github.com/googleapis/llama-index-alloydb-pg-python/pull/10/#discussion_r1859128739) to make the column names homogeneous across interfaces in this library.

Review points:
1. Should the field name change too? I prefer `node_column` or should we make it `node_data_column` which maybe too long and confusing with a `TextNode`'s actual contents.
