### PR TITLE
feat: vector store query methods

### DIFF
--- a/tests/test_async_vector_store.py
+++ b/tests/test_async_vector_store.py
@@ -30,7 +30,7 @@ from sqlalchemy import text
 from sqlalchemy.engine.row import RowMapping
 
 from llama_index_alloydb_pg import AlloyDBEngine
-from llama_index_alloydb_pg.async_vectorstore import AsyncAlloyDBVectorStore
+from llama_index_alloydb_pg.async_vector_store import AsyncAlloyDBVectorStore
 
 DEFAULT_TABLE = "test_table" + str(uuid.uuid4())
 VECTOR_SIZE = 5


### PR DESCRIPTION
Adds vector store class structure for implementing instance methods -> adelete_nodes, aget_nodes, aquery.

Review pointers:
  - Parsing of MetadataFilters (several optional values in filters)
  - Exceptions, doc blocks, comments, warnings
  - Tests for scenarios where nodes are returned

<details>

<summary>PyTest log</summary>

### Log for pytest command
`PYTHONPATH=src pytest -p warnings -W "error::UserWarning" -v --capture=tee-sys --disable-warnings tests/test_async_vectorstore.py::TestVectorStore`

```
(base) ➜  llama-index-alloydb-pg-python git:(vs-instance-methods-2) ✗ PYTHONPATH=src pytest -p warnings -W "error::UserWarning" -v --capture=tee-sys --disable-warnings tests/test_async_vectorstore.py::TestVectorStore
/usr/local/google/home/vishwarajanand/miniconda3/lib/python3.11/site-packages/pytest_asyncio/plugin.py:208: PytestDeprecationWarning: The configuration option "asyncio_default_fixture_loop_scope" is unset.
The event loop scope for asynchronous fixtures will default to the fixture caching scope. Future versions of pytest-asyncio will default the loop scope for asynchronous fixtures to function scope. Set the default fixture loop scope explicitly in order to avoid unexpected behavior in the future. Valid fixture loop scopes are: "function", "class", "module", "package", "session"

  warnings.warn(PytestDeprecationWarning(_DEFAULT_FIXTURE_LOOP_SCOPE_UNSET))
============================================================================ test session starts ============================================================================
platform linux -- Python 3.11.4, pytest-8.3.2, pluggy-1.5.0 -- /usr/local/google/home/vishwarajanand/miniconda3/bin/python
cachedir: .pytest_cache
rootdir: /usr/local/google/home/vishwarajanand/github/llama-index-alloydb-pg-python
configfile: pyproject.toml
plugins: asyncio-0.24.0, anyio-4.4.0, depends-1.0.1
asyncio: mode=Mode.STRICT, default_loop_scope=None
collected 19 items                                                                                                                                                          

tests/test_async_vectorstore.py::TestVectorStore::test_init_with_constructor PASSED                                                                                   [  5%]
tests/test_async_vectorstore.py::TestVectorStore::test_validate_id_column_create PASSED                                                                               [ 10%]
tests/test_async_vectorstore.py::TestVectorStore::test_validate_text_column_create PASSED                                                                             [ 15%]
tests/test_async_vectorstore.py::TestVectorStore::test_validate_embedding_column_create PASSED                                                                        [ 21%]
tests/test_async_vectorstore.py::TestVectorStore::test_validate_node_column_create PASSED                                                                             [ 26%]
tests/test_async_vectorstore.py::TestVectorStore::test_validate_ref_doc_id_column_create PASSED                                                                       [ 31%]
tests/test_async_vectorstore.py::TestVectorStore::test_validate_metadata_json_column_create PASSED                                                                    [ 36%]
tests/test_async_vectorstore.py::TestVectorStore::test_async_add PASSED                                                                                               [ 42%]
tests/test_async_vectorstore.py::TestVectorStore::test_adelete PASSED                                                                                                 [ 47%]
tests/test_async_vectorstore.py::TestVectorStore::test_adelete_nodes PASSED                                                                                           [ 52%]
tests/test_async_vectorstore.py::TestVectorStore::test_aget_nodes PASSED                                                                                              [ 57%]
tests/test_async_vectorstore.py::TestVectorStore::test_aquery PASSED                                                                                                  [ 63%]
tests/test_async_vectorstore.py::TestVectorStore::test_aclear PASSED                                                                                                  [ 68%]
tests/test_async_vectorstore.py::TestVectorStore::test_add PASSED                                                                                                     [ 73%]
tests/test_async_vectorstore.py::TestVectorStore::test_get_nodes PASSED                                                                                               [ 78%]
tests/test_async_vectorstore.py::TestVectorStore::test_query PASSED                                                                                                   [ 84%]
tests/test_async_vectorstore.py::TestVectorStore::test_delete PASSED                                                                                                  [ 89%]
tests/test_async_vectorstore.py::TestVectorStore::test_delete_nodes PASSED                                                                                            [ 94%]
tests/test_async_vectorstore.py::TestVectorStore::test_clear PASSED                                                                                                   [100%]

============================================================================ 19 passed in 32.99s ============================================================================
(base) ➜  llama-index-alloydb-pg-python git:(vs-instance-methods-2) ✗ 
(base) ➜  llama-index-alloydb-pg-python git:(vs-instance-methods-2) ✗ 
```

</details>

