### PR TITLE
chore: add drop index statements to avoid conflict

### DIFF
--- a/tests/test_async_vector_store_index.py
+++ b/tests/test_async_vector_store_index.py
@@ -123,6 +123,7 @@ class TestIndex:
         index = HNSWIndex()
         await vs.aapply_vector_index(index)
         assert await vs.is_valid_index(DEFAULT_INDEX_NAME)
+        await vs.adrop_vector_index(DEFAULT_INDEX_NAME)
 
     async def test_areindex(self, vs):
         if not await vs.is_valid_index(DEFAULT_INDEX_NAME):
@@ -131,6 +132,7 @@ class TestIndex:
         await vs.areindex()
         await vs.areindex(DEFAULT_INDEX_NAME)
         assert await vs.is_valid_index(DEFAULT_INDEX_NAME)
+        await vs.adrop_vector_index(DEFAULT_INDEX_NAME)
 
     async def test_dropindex(self, vs):
         await vs.adrop_vector_index()
@@ -147,6 +149,7 @@ class TestIndex:
         )
         await vs.aapply_vector_index(index)
         assert await vs.is_valid_index("secondindex")
+        await vs.adrop_vector_index()
         await vs.adrop_vector_index("secondindex")
 
     async def test_is_valid_index(self, vs):


### PR DESCRIPTION
Fixes tests for https://github.com/googleapis/llama-index-alloydb-pg-python/pull/47