### PR TITLE
chore(deps): update connectors

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-google-cloud-alloydb-connector[asyncpg]==1.8.0
+google-cloud-alloydb-connector[asyncpg]==1.9.0
 llama-index-core==0.12.35
 pgvector==0.4.1
 SQLAlchemy[asyncio]==2.0.40

--- a/tests/test_async_index_store.py
+++ b/tests/test_async_index_store.py
@@ -100,7 +100,6 @@ class TestAsyncAlloyDBIndexStore:
         yield async_engine
 
         await async_engine.close()
-        await async_engine._connector.close()
 
     @pytest_asyncio.fixture(scope="class")
     async def index_store(self, async_engine):

--- a/tests/test_async_reader.py
+++ b/tests/test_async_reader.py
@@ -98,7 +98,6 @@ class TestAsyncAlloyDBReader:
         await self._cleanup_table(async_engine)
 
         await async_engine.close()
-        await async_engine._connector.close()
 
     async def _cleanup_table(self, engine):
         await aexecute(engine, f'DROP TABLE IF EXISTS "{default_table_name_async}"')

--- a/tests/test_async_vector_store.py
+++ b/tests/test_async_vector_store.py
@@ -119,7 +119,6 @@ class TestVectorStore:
         await aexecute(engine, f'DROP TABLE IF EXISTS "{DEFAULT_TABLE}"')
         await aexecute(engine, f'DROP TABLE IF EXISTS "{DEFAULT_TABLE_CUSTOM_VS}"')
         await engine.close()
-        await engine._connector.close()
 
     @pytest_asyncio.fixture(scope="class")
     async def vs(self, engine):

--- a/tests/test_async_vector_store_index.py
+++ b/tests/test_async_vector_store_index.py
@@ -104,7 +104,6 @@ class TestIndex:
         yield engine
         await aexecute(engine, f"DROP TABLE IF EXISTS {DEFAULT_TABLE}")
         await engine.close()
-        await engine._connector.close()
 
     @pytest_asyncio.fixture(scope="class")
     async def vs(self, engine):

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -122,7 +122,6 @@ class TestEngineAsync:
         await aexecute(engine, f'DROP TABLE "{DEFAULT_IS_TABLE}"')
         await aexecute(engine, f'DROP TABLE "{DEFAULT_CS_TABLE}"')
         await engine.close()
-        await engine._connector.close()
 
     async def test_init_with_constructor(
         self,
@@ -451,7 +450,6 @@ class TestEngineSync:
         await aexecute(engine, f'DROP TABLE "{DEFAULT_VS_TABLE_SYNC}"')
         await aexecute(engine, f'DROP TABLE "{DEFAULT_CS_TABLE_SYNC}"')
         await engine.close()
-        await engine._connector.close()
 
     async def test_password(
         self,
@@ -506,7 +504,6 @@ class TestEngineSync:
         assert engine
         await aexecute(engine, "SELECT 1")
         await engine.close()
-        await engine._connector.close()
 
     async def test_init_document_store(self, engine):
         engine.init_doc_store_table(

--- a/tests/test_index_store.py
+++ b/tests/test_index_store.py
@@ -108,7 +108,6 @@ class TestAlloyDBIndexStoreAsync:
         yield async_engine
 
         await async_engine.close()
-        await async_engine._connector.close()
 
     @pytest_asyncio.fixture(scope="class")
     async def index_store(self, async_engine):
@@ -239,7 +238,6 @@ class TestAlloyDBIndexStoreSync:
         yield async_engine
 
         await async_engine.close()
-        await async_engine._connector.close()
 
     @pytest_asyncio.fixture(scope="class")
     async def index_store(self, async_engine):

--- a/tests/test_vector_store.py
+++ b/tests/test_vector_store.py
@@ -124,7 +124,6 @@ class TestVectorStoreAsync:
 
         await aexecute(sync_engine, f'DROP TABLE "{DEFAULT_TABLE}"')
         await sync_engine.close()
-        await sync_engine._connector.close()
 
     @pytest_asyncio.fixture(scope="class")
     async def vs(self, engine):
@@ -505,7 +504,6 @@ class TestVectorStoreSync:
 
         await aexecute(sync_engine, f'DROP TABLE "{DEFAULT_TABLE}"')
         await sync_engine.close()
-        await sync_engine._connector.close()
 
     @pytest_asyncio.fixture(scope="class")
     async def vs(self, engine):

--- a/tests/test_vector_store_index.py
+++ b/tests/test_vector_store_index.py
@@ -116,7 +116,6 @@ class TestIndexSync:
         yield engine
         await aexecute(engine, f"DROP TABLE IF EXISTS {DEFAULT_TABLE}")
         await engine.close()
-        await engine._connector.close()
 
     @pytest_asyncio.fixture(scope="class")
     async def vs(self, engine):
@@ -293,7 +292,6 @@ class TestAsyncIndex:
         yield engine
         await aexecute(engine, f"DROP TABLE IF EXISTS {DEFAULT_TABLE_ASYNC}")
         await engine.close()
-        await engine._connector.close()
 
     @pytest_asyncio.fixture(scope="class")
     async def vs(self, engine):


### PR DESCRIPTION
The new version of connectors are leading to test failures, ref tests in https://github.com/googleapis/llama-index-alloydb-pg-python/pull/114. The errors ([GCB Logs](https://pantheon.corp.google.com/cloud-build/builds;region=us-central1/eeefa8e3-c477-4483-a03c-d5cce88ce8b3;step=3?e=13802955&inv=1&invt=AbyJHA&mods=logs_tg_staging&project=llamaindex-alloydb-testing)) seem like coming from an additional connector close, which is now removed.

Additionally, a tech debt is added towards reconsidering an additional connector close if the underlying behavior of connectors change. ref: b/414134821